### PR TITLE
Rebrand Enclave as Aptible Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # ![](http://aptible-media-assets-manual.s3.amazonaws.com/web-horizontal-350.png)
 
-## Enclave-demo-app
+## Deploy-demo-app
 
-This application is intended to facilitate learning the features of the Aptible Enclave platform, wihtout needing to deploy _your_ application.
+This application is intended to facilitate learning the features of the Aptible Aptible Deploy platform, wihtout needing to deploy _your_ application.
 
-![](https://github.com/aptible/enclave-demo-app/blob/master/screenshots/demo.png)
+![](https://github.com/aptible/deploy-demo-app/blob/master/screenshots/demo.png)
 
 There are two way you can use this application:
 
 #### Guided experience
 
-For new users of the Enclave platform, you can deploy this application follwing step by step instructions found [here](https://www.aptible.com/documentation/enclave/tutorials/enclave-demo-app.html).
+For new users of the Aptible Deploy platform, you can deploy this application follwing step by step instructions found [here](https://www.aptible.com/documentation/deploy/tutorials/deploy-demo-app.html).
 
-This will help you deploy the app, and learn to configure additional features of the Enclave platform in a guided manner. This app even features a checklist that follows the step-by-step guide, to confirm that you have performed each step properly!
+This will help you deploy the app, and learn to configure additional features of the Aptible Deploy platform in a guided manner. This app even features a checklist that follows the step-by-step guide, to confirm that you have performed each step properly!
 
-![](https://github.com/aptible/enclave-demo-app/blob/master/screenshots/checklist.png)
+![](https://github.com/aptible/deploy-demo-app/blob/master/screenshots/checklist.png)
 
 
 #### Quick start
 
-For users who are familiar with Enclave, and simply need a web application to experiement with, these are the minimal steps needed to run this application.
+For users who are familiar with Deploy, and simply need a web application to experiement with, these are the minimal steps needed to run this application.
 
 * Create an application: `aptible apps:create $HANDLE`
 
-* Deploy the App via [Direct Docker Image Deploy](https://www.aptible.com/documentation/enclave/reference/apps/image/direct-docker-image-deploy.html) : `aptible deploy --app $HANDLE --docker-image aptible/enclave-demo-app`
+* Deploy the App via [Direct Docker Image Deploy](https://www.aptible.com/documentation/deploy/reference/apps/image/direct-docker-image-deploy.html) : `aptible deploy --app $HANDLE --docker-image aptible/deploy-demo-app`
 
 * Create an Endpoint for the application from your Dashboard.
 

--- a/app/app.py
+++ b/app/app.py
@@ -78,7 +78,7 @@ def check_env(envname, value=None):
 
 def tutorial_url(ref):
     return "{0}#{1}".format(
-        "documentation/enclave/tutorials/enclave-demo-app.html",
+        "documentation/deploy/tutorials/deploy-demo-app.html",
         ref
     )
 
@@ -117,11 +117,11 @@ def checklist(url):
     check("Run database migrations", migrations,
           tutorial_url("run-database-migrations"))
     check("Advanced: Application: scale your app up or down", scaled,
-          "documentation/enclave/reference/apps/scaling.html#vertical-scaling")
+          "documentation/deploy/reference/apps/scaling.html#vertical-scaling")
     check("Advanced: Endpoints: force redirection to HTTPS", check_env("FORCE_SSL", "true"),
-          "documentation/enclave/reference/apps/endpoints/https-endpoints/https-redirect.html")
+          "documentation/deploy/reference/apps/endpoints/https-endpoints/https-redirect.html")
     check("Advanced: Endpoints: change default timeout", check_env("IDLE_TIMEOUT"),
-          "documentation/enclave/reference/apps/endpoints/timeouts.html#endpoint-timeouts")
+          "documentation/deploy/reference/apps/endpoints/timeouts.html#endpoint-timeouts")
 
     return setup_status
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Enclave Demo App</title>
+    <title>Aptible Deploy Demo App</title>
     <script src="https://use.typekit.net/pqi8lpw.js"></script>
     <script>try { Typekit.load({ async: false }); } catch(e) {}</script>
     <link rel="stylesheet" href="static/all.css" />
@@ -29,7 +29,7 @@
           </g>
         </g>
       </svg>
-      <h1>Welcome to Enclave!</h1>
+      <h1>Welcome to Aptible Deploy!</h1>
     </header>
 
     <section class="app-input">

--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,4 @@
 REGISTRY = quay.io
-REPOSITORY = aptible/enclave-demo-app
+REPOSITORY = aptible/deploy-demo-app
 
 PUSH_REGISTRIES = $(REGISTRY) docker.io


### PR DESCRIPTION
I will also rename the repo enclave-demo-app -> deploy-demo-app, per the hyperlink in aptible/docs.

This will eventually need to receive a style update, as well.