### PR TITLE
Update psycopg to fix libc linking issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Jinja2==2.9.6
 honcho==1.0.1
 Mako==1.0.6
 MarkupSafe==1.0
-psycopg2==2.7.1
+psycopg2==2.7.3.2
 python-editor==1.0.3
 redis==2.10.5
 rq==0.5.6


### PR DESCRIPTION
When deploying the demo app during onboarding, I got the following error when Deploy attempted to run `gunicorn`:

```
ImportError: /usr/local/lib/python3.5/site-packages/psycopg2/.libs/libresolv-2-c4c53def.5.so: symbol __res_maybe_init version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference
```

I was able to recreate by building the docker image locally and running `gunicorn` directly in it.

Googling found a [GitHub issue comment for resolving it](https://github.com/taigaio/taiga-back/issues/1122#issuecomment-397553993) by bumping the psycopg patch version.

I applied the fix to the `requirements.txt` then confirmed it fixed locally and in Aptible Deploy.