### PR TITLE
upgrade MarkupSafe to 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ itsdangerous==0.24
 Jinja2==2.10.1
 honcho==1.0.1
 Mako==1.0.6
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 psycopg2==2.7.3.2
 python-editor==1.0.3
 redis==2.10.5


### PR DESCRIPTION
dependency setuptools introduced a breaking change in 46.0.0: https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4600
> #65: Once again as in 3.0, removed the Features feature.

This broke MarkupSafe 1.0, was fixed in 1.1.  Version 1.1.1 is latest.