### PR TITLE
Put Procfile in a location that makes the app standalone deployable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN pip install -r requirements.txt
 
 # Add repo contents to image
 ADD app/ /app/
+ADD Procfile /.aptible/Procfile
 
 ENV PORT 5000
 EXPOSE 5000


### PR DESCRIPTION
I spent wayyyy too long trying to figure out why the image wasn't picking up services automatically. Turns out I just falsely assumed we were already doing this. 