### PR TITLE
Deployment improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
 # Dockerfile
-FROM python:3.5
-
-# PostgreSQL dev headers and client (uncomment if you use PostgreSQL)
-#RUN apt-install libpq-dev postgresql-client-9.3 postgresql-contrib-9.3
+FROM python:3.5-slim
 
 # Add requirements.txt ONLY, then run pip install, so that Docker cache won't
-# bust when changes are made to other repo files
+# be invalidated when changes are made to other repo files
+
 ADD requirements.txt /app/
 WORKDIR /app
 RUN pip install -r requirements.txt
+
+# WARNING: the following is applicable only for Direct Docker Image Deployment
+# For Dockerfile (git-based) deployments, only the Procfile and .aptible.yml in the root of the repository matter
+# See https://www.aptible.com/documentation/deploy/reference/apps/services/procfiles.html#procfiles
+# and https://www.aptible.com/documentation/deploy/reference/apps/aptible-yml.html#aptible-yml
+
+ADD Procfile /.aptible/
+ADD migrations /.aptible/aptible.yml
 
 # Add repo contents to image
 ADD app/ /app/
 
 ENV PORT 5000
 EXPOSE 5000
-
-CMD ["honcho", "start", "-f", "/app/honcho.cnf"]

--- a/app/honcho.cnf
+++ b/app/honcho.cnf
@@ -1,3 +1,0 @@
-#Procfile
-web: gunicorn app:app -b 0.0.0.0:$PORT --access-logfile -
-background: python worker.py

--- a/migrations
+++ b/migrations
@@ -1,0 +1,2 @@
+before_release:
+  - python migrations.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ Flask-WTF==0.14.2
 gunicorn==19.7.1
 itsdangerous==0.24
 Jinja2==2.10.1
-honcho==1.0.1
 Mako==1.0.6
 MarkupSafe==1.1.1
 psycopg2==2.7.3.2


### PR DESCRIPTION
* Use the -slim parent image to speed up deploys.
* Remove honcho, which was a crutch before the functionality of .aptible/Procfile was added
* add an .aptible.yml to the image in case of direct docker image deployment