### PR TITLE
Updated GHA to run off master branch

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,7 +2,7 @@ name: build-and-push-docker-image
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   release:
     types:
       - created


### PR DESCRIPTION
currently looking for `[ main ]`, but should run off master (this repo's main branch)