### PR TITLE
Push changes to the default branch to DockerHub as latest

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,10 +2,8 @@ name: build-and-push-docker-image
 
 on:
   push:
-    branches: [ main ]
-  release:
-    types:
-      - created
+    branches: 
+      - main
 
 jobs:
   push-image:
@@ -26,6 +24,8 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: aptible/deploy-demo-app
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v2


### PR DESCRIPTION
The current `latest` tag is 4 years old whereas `main` was updated in the last month. I believe we want all of our changes to the `main` branch to be [tagged as latest](https://github.com/docker/metadata-action?tab=readme-ov-file#latest-tag).