### PR TITLE
fix: update Dockerfile for Aptible deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.12-slim
 
 # build-essential is needed for various python dependencies (gcc + others are in build-essential)
 # libpq-dev is needed for psycopg2 to be installed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![](https://github.com/aptible/mintlify-docs/blob/073bfba084ad9ea18217f5816568c3f832d5f0ae/logo/light.png)
+<img src="https://github.com/aptible/mintlify-docs/blob/073bfba084ad9ea18217f5816568c3f832d5f0ae/logo/light.png" height="150"/>
 
 ## deploy-demo-app
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This application is intended to facilitate learning the features of the Aptible Deploy platform, without
 needing to deploy _your_ application.
 
-![](https://github.com/aptible/deploy-demo-app/blob/master/screenshots/demo.png)
+![](https://github.com/aptible/deploy-demo-app/blob/main/screenshots/demo.png)
 
 There are two ways you can use this application (in sections below): Guided Experience (1) and Quickstart (2)
 
@@ -18,7 +18,7 @@ This will help you deploy the app, and learn to configure additional features of
 in a guided manner. This app even features a checklist that follows the step-by-step guide, to confirm 
 that you have performed each step properly!
 
-![](https://github.com/aptible/deploy-demo-app/blob/master/screenshots/checklist.png)
+![](https://github.com/aptible/deploy-demo-app/blob/main/screenshots/checklist.png)
 
 
 ### Quick start (2)
@@ -35,7 +35,7 @@ For users who are familiar with Deploy, and simply need a web application to exp
 git clone git@github.com:aptible/deploy-demo-app.git 
 cd deploy-demo-app 
 git remote add aptible git@beta.aptible.com:$ENVIRONMENT/$HANDLE.git 
-git push aptible master
+git push aptible main
 ```
 
 * Set the configuration for your database, force HTTPS only, and increase the scale:
@@ -53,7 +53,7 @@ aptible config:set \
 
 ## Copyright
 
-Copyright (c) 2022 [Aptible](https://www.aptible.com). All rights reserved.
+Copyright (c) 2024 [Aptible](https://www.aptible.com). All rights reserved.
 
 [<img src="https://avatars2.githubusercontent.com/u/1580788?v=4&s=60" />](https://github.com/UserNotFound)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![](https://framerusercontent.com/images/zPgE6unsAGcnam377HJMPuSoEho.svg)
+# ![](https://github.com/aptible/mintlify-docs/blob/073bfba084ad9ea18217f5816568c3f832d5f0ae/logo/light.png)
 
 ## deploy-demo-app
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ that you have performed each step properly!
 For users who are familiar with Deploy, and simply need a web application to experiment with, these
  are the minimal steps needed to run this application.
 
-* Create an application: `aptible apps:create $HANDLE`
+* Create an application
+  * via the [Aptible Dashboard here](https://app.aptible.com/create/app), or
+  * via the [Aptible CLI](https://www.aptible.com/docs/reference/aptible-cli/cli-commands/cli-apps-create): `aptible apps:create $HANDLE`
 * Deploy the App - CHOOSE ONE:
   * [Direct Docker Deploy](https://www.aptible.com/documentation/deploy/reference/apps/image/direct-docker-image-deploy.html) : `aptible deploy --app $HANDLE --docker-image aptible/deploy-demo-app`
-  * [Dockerfile Deploy](https://deploy-docs.aptible.com/docs/dockerfile-deploy-example): 
+  * [Dockerfile Deploy](https://deploy-docs.aptible.com/docs/dockerfile-deploy-example)
   
 ```shell
 git clone git@github.com:aptible/deploy-demo-app.git 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For users who are familiar with Deploy, and simply need a web application to exp
  are the minimal steps needed to run this application.
 
 * Create an application
-  * via the [Aptible Dashboard here](https://app.aptible.com/create/app), or
+  * via the [Aptible Dashboard](https://app.aptible.com/apps), or
   * via the [Aptible CLI](https://www.aptible.com/docs/reference/aptible-cli/cli-commands/cli-apps-create): `aptible apps:create $HANDLE`
 * Deploy the App - CHOOSE ONE:
   * [Direct Docker Deploy](https://www.aptible.com/documentation/deploy/reference/apps/image/direct-docker-image-deploy.html) : `aptible deploy --app $HANDLE --docker-image aptible/deploy-demo-app`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![](https://www.aptible.com/static/aptible-logo-dark-f7de71beb81b1638c34f88d100804d1b.png)
+# ![](https://framerusercontent.com/images/zPgE6unsAGcnam377HJMPuSoEho.svg)
 
 ## deploy-demo-app
 
@@ -12,7 +12,7 @@ There are two ways you can use this application (in sections below): Guided Expe
 ### Guided experience (1)
 
 For new users of the Aptible Deploy platform, you can deploy this application following step-by-step 
-instructions found [here](https://www.aptible.com/documentation/deploy/tutorials/deploy-demo-app.html).
+instructions found [here](https://www.aptible.com/docs/getting-started/deploy-starter-template/python-flask).
 
 This will help you deploy the app, and learn to configure additional features of the Aptible Deploy platform 
 in a guided manner. This app even features a checklist that follows the step-by-step guide, to confirm 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/aptible/mintlify-docs/blob/073bfba084ad9ea18217f5816568c3f832d5f0ae/logo/light.png" height="100"/>
+# ![](https://framerusercontent.com/images/zPgE6unsAGcnam377HJMPuSoEho.svg)
 
 ## deploy-demo-app
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/aptible/mintlify-docs/blob/073bfba084ad9ea18217f5816568c3f832d5f0ae/logo/light.png" height="150"/>
+<img src="https://github.com/aptible/mintlify-docs/blob/073bfba084ad9ea18217f5816568c3f832d5f0ae/logo/light.png" height="100"/>
 
 ## deploy-demo-app
 


### PR DESCRIPTION
## Summary
* fix: pin base image to `python:3.12-slim` to avoid deployment crashes
* docs: update `master` references to `main`
* docs: update some links

## Context
Deploying the app currently fails during migrations as deployment chooses Python 3.13.

## Testing
Tested by creating and using a git deployment.