### PR TITLE
fix import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ async-timeout==4.0.2
 click==8.1.3
 Deprecated==1.2.13
 Flask==2.2.5
-Flask-WTF==1.0.1
+Flask-WTF==1.2.2
 gunicorn==23.0.0
 importlib-metadata==4.11.3
 itsdangerous==2.1.2


### PR DESCRIPTION
Fix this error:

> ImportError: cannot import name 'url_encode' from 'werkzeug.urls' (/usr/local/lib/python3.12/site-packages/werkzeug/urls.py)

Need a slightly newer version of flask-wtf, since werkzeugh 3+ doesn't include that anymore.
